### PR TITLE
Prevent a crash that could occur if bot creation fails and bot is nil.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "XBot"]
 	path = XBot
-	url = git@github.com:modcloth-labs/XBot.git
+	url = https://github.com/modcloth-labs/XBot.git
 [submodule "Alamofire"]
 	path = Alamofire
-	url = git@github.com:modcloth-labs/Alamofire.git
+	url = https://github.com/modcloth-labs/Alamofire.git

--- a/XBotBuilder/XBotBuilder/GitHubXBotSync.swift
+++ b/XBotBuilder/XBotBuilder/GitHubXBotSync.swift
@@ -191,7 +191,11 @@ class GitHubXBotSync {
             
             botServer.createBot(botConfig){ (success, bot) in
                 let status = success ? "COMPLETED" : "FAILED"
-                println("\(bot!.name) (\(bot!.id)) creation \(status)")
+                if let createdBot = bot {
+                    println("\(bot!.name) (\(bot!.id)) creation \(status)")
+                } else {
+                    println("Bot creation \(status)")
+                }
 
                 if success {
                     bot?.integrate { (success, integration) in


### PR DESCRIPTION
If bot creation fails and bot is `nil`, the app was crashing on the forced unwrapping.
